### PR TITLE
Remove unsafe code, fix clippy lints

### DIFF
--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -20,10 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-use base32;
 use hmacsha1::hmac_sha1;
-use rand;
-use std::{mem, error, fmt, result};
+use std::{error, fmt, result};
 use std::time::{SystemTime, UNIX_EPOCH};
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 
@@ -68,9 +66,9 @@ impl fmt::Display for ErrorCorrectionLevel {
 }
 
 #[cfg(feature = "with-qrcode")]
-impl Into<qrcode::EcLevel> for ErrorCorrectionLevel {
-    fn into(self) -> qrcode::EcLevel {
-        match self {
+impl From<ErrorCorrectionLevel> for qrcode::EcLevel {
+    fn from(level: ErrorCorrectionLevel) -> Self {
+        match level {
             ErrorCorrectionLevel::High => EcLevel::H,
             ErrorCorrectionLevel::Medium => EcLevel::M,
             ErrorCorrectionLevel::Quartile => EcLevel::Q,

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -178,11 +178,7 @@ impl GoogleAuthenticator {
         let offset = hash[hash.len() - 1] & 0x0F;
         let mut truncated_hash: [u8; 4] = Default::default();
         truncated_hash.copy_from_slice(&hash[offset as usize..(offset + 4) as usize]);
-        let mut code: i32 = unsafe { mem::transmute::<[u8; 4], i32>(truncated_hash) };
-        if cfg!(target_endian = "big") {
-        } else {
-            code = i32::from_be(code);
-        }
+        let mut code = i32::from_be_bytes(truncated_hash);
         code &= 0x7FFFFFFF;
         code %= 1_000_000;
         let mut code_str = code.to_string();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,10 +140,10 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "with-qrcode")]
     fn test_verify_code() {
         let auth = GoogleAuthenticator::new();
         let secret = "I3VFM3JKMNDJCDH5BMBEEQAW6KJ6NOE3";
+        #[cfg(feature = "with-qrcode")]
         println!(
             "{:?}",
             auth.qr_code(secret, "qr_code", "name", 0, 0, Medium)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ mod tests {
     fn test_code() {
         let auth = GoogleAuthenticator::new();
         let secret = "I3VFM3JKMNDJCDH5BMBEEQAW6KJ6NOE3";
-        assert_eq!(6, auth.get_code(&secret, 0).unwrap().len());
+        assert_eq!(6, auth.get_code(secret, 0).unwrap().len());
     }
 
     #[test]
@@ -186,13 +186,13 @@ mod macro_tests {
     #[test]
     fn test_code() {
         let secret = "I3VFM3JKMNDJCDH5BMBEEQAW6KJ6NOE3";
-        assert_eq!(6, get_code!(&secret).unwrap().len());
+        assert_eq!(6, get_code!(secret).unwrap().len());
     }
 
     #[test]
     fn test_verify_code() {
         let secret = "I3VFM3JKMNDJCDH5BMBEEQAW6KJ6NOE3";
-        let code = get_code!(&secret).unwrap();
+        let code = get_code!(secret).unwrap();
         assert!(verify_code!(secret, &code));
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(missing_docs)]
+#![deny(unsafe_code)]
 // Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ macro_rules! create_secret {
 }
 
 /// A macro that can be used for convenient access to the function
-/// `GoogleAuthenticator::create_secret`, by providing a default of the current time to the
+/// `GoogleAuthenticator::get_code`, by providing a default of the current time to the
 /// `times_slice` parameter.
 #[macro_export]
 macro_rules! get_code {


### PR DESCRIPTION
This removes the unneeded unsafe code used to convert from [u8; 4] to i32. The standard library handles this as of Rust 1.32. I was not able to compile this project with 1.32 prior to these changes, so this should not impact what Rust versions this crate compiles on.

The other changes are to fix clippy lints. The most notable is changing from an `Into` impl to a `From` impl in one spot, which technically changes the public API when `with-qrcode` is used (but in a non-breaking way; it only adds the ::from(...) method, the Into trait is auto-implemented with From)

Also one minor doc fix in there.

Finally I moved the 'with-qrcode' requirement for testing verify_code, since otherwise plain 'cargo test' does not catch an algorithm error (eg, change 'from_be_bytes' to 'from_le_bytes')