### PR TITLE
Added Changelog and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on: [push, pull_request]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build
+    - name: Run tests
+      run: cargo test
+    - name: Format
+      run: cargo fmt -- --check
+    - name: Linting
+      run: cargo clippy -- -D warnings
+    - name: Audit
+      run: |
+        cargo update
+        cargo audit
+      # Allowed to fail but this will notify us that some dependency might need an update.
+      continue-on-error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+This application follows the [Semantic Versioning standard](https://semver.org/).
+
+## Unreleased
+- 
+
+## Version 0.3.0 (2021-11-15)
+- Removed all unsafe code. (#9)
+- Change in policy, there is no need for unsafe code in the future. (#9)
+- `qrcode::EcLevel` implements `From<ErrorCorrectionLevel>` instead for
+`ErrorCorrectionLevel` implementing `Into<qrcode::EcLevel>`
+(only when "with-qrcode" feature is enabled). (#9)
+
+## Pre version 0.3.0 (2020-10-12)
+All changes before 2020-10-12 where not documented.
+This is everything before and including: 388f6933301df132aaf94982b7f15c9dce3f2e06

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -21,9 +21,9 @@
 // SOFTWARE.
 
 use hmacsha1::hmac_sha1;
-use std::{error, fmt, result};
-use std::time::{SystemTime, UNIX_EPOCH};
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
+use std::time::{SystemTime, UNIX_EPOCH};
+use std::{error, fmt, result};
 
 #[cfg(feature = "with-qrcode")]
 use qrcode::render::svg;


### PR DESCRIPTION
It would be very helpful if this library keeps a changelog.
This is helpful for a lot of reasons. 

One of them is: 
The update from 0.2.1 to 0.3.0 I don't know what parts where changed and what breaking changes have happened.

This adds the last update to the change log.

I also added GitHub CI to automatically run build, tests, formatting, linting and audit on the repo.
This makes future reviews easier and less error prone.

This does not change the actual library in any way, so no release is needed for this.